### PR TITLE
Add CrawlFailed event for failed job handling

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,8 @@
         "php": "^8.0",
         "dbrekelmans/bdi": "^1.2",
         "frictionlessdigital/actions": "^9.0|^10.0|^11.0",
-        "illuminate/contracts": "^8.0|^9.0|^10.0|^11.0",
-        "spatie/laravel-package-tools": "^1.12",
+        "illuminate/contracts": "^8.0|^9.0|^10.0|^11.0|^12.0",
+        "spatie/laravel-package-tools": "^1.12|^1.20",
         "symfony/browser-kit": "^6.0|^7.0",
         "symfony/http-client": "^6.0|^7.0",
         "symfony/panther": "^2.1"
@@ -28,8 +28,8 @@
     "require-dev": {
         "dg/bypass-finals": "^1.7",
         "nunomaduro/collision": "^5.0|^6.0|^7.0|^8.0",
-        "orchestra/testbench": "^6.0|^7.0|^8.0|^9.0",
-        "pestphp/pest": "^1.0|^2.0",
+        "orchestra/testbench": "^6.0|^7.0|^8.0|^9.0|^10.0",
+        "pestphp/pest": "^1.0|^2.0|^3.0",
         "phpspec/prophecy": "~1.0"
     },
     "autoload": {

--- a/src/CrawlTraveller.php
+++ b/src/CrawlTraveller.php
@@ -82,9 +82,11 @@ class CrawlTraveller
      */
     public function clearBrowser(): self
     {
-        $this->browser->quit();
+        if($this->browser){
+            $this->browser->quit();
 
-        $this->browser = null;
+            $this->browser = null;
+        }
 
         return $this;
     }

--- a/src/CrawlTraveller.php
+++ b/src/CrawlTraveller.php
@@ -22,6 +22,9 @@ class CrawlTraveller
     /** @var \TrueRcm\LaravelWebscrape\Contracts\CrawlResult[] */
     protected array $crawledPages = [];
 
+    /** @var bool */
+    protected bool $crawlOldPages = false;
+
     /**
      * Create new CrawlTraveller.
      */
@@ -141,6 +144,24 @@ class CrawlTraveller
      */
     public function getCrawledPages(): Collection
     {
+        if($this->crawlOldPages){
+            $this->subject()
+                ->crawlResults
+                ->each(fn(CrawlResult $page) => $this->addCrawledPage($page));
+        }
+
         return collect($this->crawledPages);
+    }
+
+    public function crawlOldPages()
+    {
+        $this->crawlOldPages = true;
+
+        return $this;
+    }
+
+    public function doNotCrawlOldPages(): bool
+    {
+        return !$this->crawlOldPages;
     }
 }

--- a/src/Events/CrawlAuthFailed.php
+++ b/src/Events/CrawlAuthFailed.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace TrueRcm\LaravelWebscrape\Events;
+
+use Illuminate\Support\Facades\Log;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+use TrueRcm\LaravelWebscrape\Contracts\CrawlSubject;
+
+class CrawlAuthFailed
+{
+    use Dispatchable;
+    use InteractsWithSockets;
+    use SerializesModels;
+
+    public CrawlSubject $subject;
+
+    public function __construct(
+        public int $subjectId
+    ) {
+        $this->subject = app(CrawlSubject::class)->find($this->subjectId);
+    }
+}

--- a/src/Events/CrawlCompleted.php
+++ b/src/Events/CrawlCompleted.php
@@ -13,8 +13,11 @@ class CrawlCompleted
     use InteractsWithSockets;
     use SerializesModels;
 
+    public CrawlSubject $subject;
+
     public function __construct(
-        public CrawlSubject $subject
+        public int $subjectId
     ) {
+        $this->subject = app(CrawlSubject::class)->find($this->subjectId);
     }
 }

--- a/src/Events/CrawlFailed.php
+++ b/src/Events/CrawlFailed.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace TrueRcm\LaravelWebscrape\Events;
+
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+use TrueRcm\LaravelWebscrape\Contracts\CrawlSubject;
+
+class CrawlFailed
+{
+    use Dispatchable;
+    use InteractsWithSockets;
+    use SerializesModels;
+
+    public function __construct(
+        public CrawlSubject $subject
+    ) {
+    }
+}

--- a/src/Exceptions/CrawlException.php
+++ b/src/Exceptions/CrawlException.php
@@ -37,7 +37,9 @@ final class CrawlException extends \Exception
      */
     public static function authenticationFailed(CrawlTraveller $traveller): static
     {
-        $message = __('Authentication failed for given credentials');
+        $message = __('Authentication failed for subject Id :id', [
+            'id' => $traveller->subject()->id,
+        ]);
 
         return new static($message);
     }

--- a/src/Exceptions/CrawlException.php
+++ b/src/Exceptions/CrawlException.php
@@ -69,4 +69,17 @@ final class CrawlException extends \Exception
 
         return new static($message);
     }
+
+    /**
+     * @param int $crawlResultId
+     * @return static
+     */
+    public static function crawlResultNotFound(int $crawlResultId): static
+    {
+        $message = __('CrawlResult not found for Id :id', [
+            'id' => $crawlResultId,
+        ]);
+
+        return new static($message);
+    }
 }

--- a/src/Jobs/CrawlTargetJob.php
+++ b/src/Jobs/CrawlTargetJob.php
@@ -103,7 +103,7 @@ class CrawlTargetJob implements ShouldQueue, ShouldBeUnique
 
         $batch->allowFailures()->dispatch();
 
-        Log::info('Webscrape: batch dispatched for subject ID: {$subjectKey}');
+        Log::info("Webscrape: batch dispatched for subject ID: {$subjectKey}");
     }
 
     public function failed(\Throwable $exception): void

--- a/src/Jobs/CrawlTargetJob.php
+++ b/src/Jobs/CrawlTargetJob.php
@@ -84,7 +84,7 @@ class CrawlTargetJob implements ShouldQueue, ShouldBeUnique
 
         /* define the bus batch */
         $batch = Bus::batch([])
-            ->then(function(Batch $batch) use($subjectKey, $pages){
+            ->then(function($batch) use($subjectKey, $pages){
                 $batch2 = Bus::batch([]);
                 /* add jobs to the batch */
                 $pages
@@ -94,7 +94,7 @@ class CrawlTargetJob implements ShouldQueue, ShouldBeUnique
                 $batch2->add([new ProcessParsedResultsJob($subjectKey, $pages)])
                     ->dispatch();
             })
-            ->finally(fn(Batch $batch) => CrawlCompleted::dispatch($subjectKey));
+            ->finally(fn($batch) => CrawlCompleted::dispatch($subjectKey));
 
         /* add jobs to the batch */
         $pages

--- a/src/Jobs/CrawlTargetJob.php
+++ b/src/Jobs/CrawlTargetJob.php
@@ -2,6 +2,7 @@
 
 namespace TrueRcm\LaravelWebscrape\Jobs;
 
+use Illuminate\Bus\Batch;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
@@ -40,50 +41,65 @@ class CrawlTargetJob implements ShouldQueue
      */
     public function handle(Pipeline $pipeline): void
     {
-        Log::info("Webscrape: initiated");
+        Log::info("Webscrape: initiated for subject ID: {$this->traveller->subject()->getKey()}");
 
         CrawlStarted::dispatch($this->traveller->subject());
 
-        $pipeline
-            ->send($this->traveller)
-            ->through([
-                AuthenticateBrowser::class,
-                CrawlPages::class,
-                CloseBrowser::class,
-            ])->then(function (CrawlTraveller $traveller) {
+        try {
+            $pipeline
+                ->send($this->traveller)
+                ->through([
+                    AuthenticateBrowser::class,
+                    CrawlPages::class,
+                    CloseBrowser::class,
+                ])
+                ->then(function (CrawlTraveller $traveller) {
+                    $this->dispatchPostCrawlJobs($traveller);
+                });
+        } catch (\Throwable $exception) {
+            $this->handleCrawlFailure($exception);
+        } finally {
+            $this->traveller->clearBrowser();
+        }
+    }
 
-                //Extracts the IDs to fix serialization issue
-                $pages = $traveller->getCrawledPages()->pluck('id');
-                $subjectKey = $traveller->subject()->getKey();
+    /**
+     * Dispatch the jobs that should run after crawling is complete.
+     */
+    protected function dispatchPostCrawlJobs(CrawlTraveller $traveller): void
+    {
+        $pages = $traveller->getCrawledPages()->pluck('id');
+        $subjectKey = $traveller->subject()->getKey();
 
-                Log::info("Webscrape: {$pages->count()} Pages crawled");
+        Log::info("Webscrape: {$pages->count()} Pages crawled for subject ID: {$subjectKey}");
 
-                /* define the bus batch */
-                $batch = Bus::batch([])
-                    ->then(function($batch) use($subjectKey, $pages){
-                        $batch2 = Bus::batch([]);
-                        /* add jobs to the batch */
-                        $pages
-                        ->map(fn($id) => new PersistParseResult($id)) // Persist Parse result with Result IDs
-                        ->pipe(fn(Collection $all) => $batch2->add($all));
+        Bus::batch([
+            // Create jobs for parsing
+            $pages->map(fn($id) => new ParseCrawledPage($id)),
+        ])
+        ->then(function(Batch $batch) use($subjectKey, $pages) { // Use type hint Batch
+            // Create jobs for persisting parse results and processing them
+            Bus::batch([
+                $pages->map(fn($id) => new PersistParseResult($id)),
+                [new ProcessParsedResultsJob($subjectKey, $pages)],
+            ])->dispatch();
+        })
+        ->finally(fn(Batch $batch) => CrawlCompleted::dispatch($subjectKey)) // Use type hint Batch
+        ->allowFailures()
+        ->dispatch();
 
-                        $batch2->add([new ProcessParsedResultsJob($subjectKey, $pages)])
-                            ->dispatch();
-                    })
-                    ->finally(fn($batch) => CrawlCompleted::dispatch($subjectKey));
-
-                /* add jobs to the batch */
-                $pages
-                ->map(fn($id) => new ParseCrawledPage($id)) // Creates ParseCrawledPage jobs with IDs
-                ->pipe(fn(Collection $all) => $batch->add($all)); // Adds jobs to the batch
-
-                $batch->allowFailures()->dispatch();
-
-                Log::info('Webscrape: bus dispatched');
-            });
+        Log::info('Webscrape: batch dispatched');
     }
 
     public function failed(\Throwable $exception): void
+    {
+        $this->handleCrawlFailure($exception);
+    }
+
+    /**
+     * Centralized crawl failure handling.
+     */
+    protected function handleCrawlFailure(\Throwable $exception): void
     {
         $subject = $this->traveller->subject();
 
@@ -91,7 +107,7 @@ class CrawlTargetJob implements ShouldQueue
             'result' => []
         ]);
 
-        Log::error("CrawlTargetJob Error: Job failed for subject {$subject->id}", [
+        Log::error("CrawlTargetJob Error: Job failed for subject {$subject->getKey()}", [
             'error' => $exception->getMessage(),
             'trace' => $exception->getTraceAsString()
         ]);

--- a/src/Jobs/CrawlTargetJob.php
+++ b/src/Jobs/CrawlTargetJob.php
@@ -11,8 +11,10 @@ use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Log;
+use TrueRcm\LaravelWebscrape\Actions\UpdateCrawlSubject;
 use TrueRcm\LaravelWebscrape\CrawlTraveller;
 use TrueRcm\LaravelWebscrape\Events\CrawlCompleted;
+use TrueRcm\LaravelWebscrape\Events\CrawlFailed;
 use TrueRcm\LaravelWebscrape\Events\CrawlStarted;
 use TrueRcm\LaravelWebscrape\Pipes\AuthenticateBrowser;
 use TrueRcm\LaravelWebscrape\Pipes\CloseBrowser;
@@ -60,6 +62,11 @@ class CrawlTargetJob implements ShouldQueue
                     ->then(fn($batch) => ProcessParsedResultsJob::dispatch($subject, $pages))
                     ->finally(fn($batch) => CrawlCompleted::dispatch($subject));
 
+                /* define the bus batch */
+//                $batch = Bus::batch([])
+//                    ->then(fn($batch) => ProcessParsedResultsJob::dispatch($subject, $pages))
+//                    ->finally(fn($batch) => CrawlCompleted::dispatch($subject));
+
                 /* prepare the batches */
                 $pages->mapInto(ParseCrawledPage::class)
                     ->pipe(fn(Collection $all) => $batch->add($all));
@@ -68,5 +75,21 @@ class CrawlTargetJob implements ShouldQueue
 
                 Log::info('Webscrape: bus dispatched');
             });
+    }
+
+    public function failed(\Throwable $exception): void
+    {
+        $subject = $this->traveller->subject();
+
+        UpdateCrawlSubject::run($subject, [
+            'result' => []
+        ]);
+
+        Log::error("CrawlTargetJob Error: Job failed for subject {$subject->id}", [
+            'error' => $exception->getMessage(),
+            'trace' => $exception->getTraceAsString()
+        ]);
+
+        CrawlFailed::dispatch($subject);
     }
 }

--- a/src/Jobs/CrawlTargetJob.php
+++ b/src/Jobs/CrawlTargetJob.php
@@ -63,13 +63,14 @@ class CrawlTargetJob implements ShouldQueue
                     ->finally(fn($batch) => CrawlCompleted::dispatch($subject));
 
                 /* define the bus batch */
-//                $batch = Bus::batch([])
-//                    ->then(fn($batch) => ProcessParsedResultsJob::dispatch($subject, $pages))
-//                    ->finally(fn($batch) => CrawlCompleted::dispatch($subject));
+                $pages->pluck('id') // Extracts the IDs from the $pages collection
+                ->map(fn($id) => new ParseCrawledPage($id)) // Creates ParseCrawledPage jobs with IDs
+                ->pipe(fn(Collection $all) => $batch->add($all)); // Adds jobs to the batch
+
 
                 /* prepare the batches */
-                $pages->mapInto(ParseCrawledPage::class)
-                    ->pipe(fn(Collection $all) => $batch->add($all));
+//                $pages->mapInto(ParseCrawledPage::class)
+//                    ->pipe(fn(Collection $all) => $batch->add($all));
 
                 $batch->dispatch();
 

--- a/src/Jobs/CrawlTargetJob.php
+++ b/src/Jobs/CrawlTargetJob.php
@@ -4,6 +4,7 @@ namespace TrueRcm\LaravelWebscrape\Jobs;
 
 use Illuminate\Bus\Batch;
 use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Pipeline\Pipeline;
@@ -12,6 +13,7 @@ use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
 use TrueRcm\LaravelWebscrape\Actions\UpdateCrawlSubject;
 use TrueRcm\LaravelWebscrape\CrawlTraveller;
 use TrueRcm\LaravelWebscrape\Events\CrawlCompleted;
@@ -21,7 +23,7 @@ use TrueRcm\LaravelWebscrape\Pipes\AuthenticateBrowser;
 use TrueRcm\LaravelWebscrape\Pipes\CloseBrowser;
 use TrueRcm\LaravelWebscrape\Pipes\CrawlPages;
 
-class CrawlTargetJob implements ShouldQueue
+class CrawlTargetJob implements ShouldQueue, ShouldBeUnique
 {
     use Dispatchable;
     use InteractsWithQueue;
@@ -119,5 +121,12 @@ class CrawlTargetJob implements ShouldQueue
         ]);
 
         CrawlFailed::dispatch($subject);
+    }
+
+    public function uniqueId()
+    {
+        $sitePrefix = Str::slug(config('app.name', 'default-site'), '_');
+        return $sitePrefix. ':' .$this->traveller->subject()
+                ->model_id;
     }
 }

--- a/src/Jobs/CrawlTargetJob.php
+++ b/src/Jobs/CrawlTargetJob.php
@@ -30,6 +30,13 @@ class CrawlTargetJob implements ShouldQueue, ShouldBeUnique
     use Queueable;
     use SerializesModels;
 
+    /**
+     * The number of seconds the job can run before timing out.
+     *
+     * @var int
+     */
+    public $timeout = 600;
+
     public function __construct(
         protected CrawlTraveller $traveller
     ) {

--- a/src/Jobs/CrawlTargetJob.php
+++ b/src/Jobs/CrawlTargetJob.php
@@ -52,27 +52,32 @@ class CrawlTargetJob implements ShouldQueue
                 CloseBrowser::class,
             ])->then(function (CrawlTraveller $traveller) {
 
-                $pages = $traveller->getCrawledPages();
-                $subject = $traveller->subject();
+                //Extracts the IDs to fix serialization issue
+                $pages = $traveller->getCrawledPages()->pluck('id');
+                $subjectKey = $traveller->subject()->getKey();
 
                 Log::info("Webscrape: {$pages->count()} Pages crawled");
 
                 /* define the bus batch */
                 $batch = Bus::batch([])
-                    ->then(fn($batch) => ProcessParsedResultsJob::dispatch($subject, $pages))
-                    ->finally(fn($batch) => CrawlCompleted::dispatch($subject));
+                    ->then(function($batch) use($subjectKey, $pages){
+                        $batch2 = Bus::batch([]);
+                        /* add jobs to the batch */
+                        $pages
+                        ->map(fn($id) => new PersistParseResult($id)) // Persist Parse result with Result IDs
+                        ->pipe(fn(Collection $all) => $batch2->add($all));
 
-                /* define the bus batch */
-                $pages->pluck('id') // Extracts the IDs from the $pages collection
+                        $batch2->add([new ProcessParsedResultsJob($subjectKey, $pages)])
+                            ->dispatch();
+                    })
+                    ->finally(fn($batch) => CrawlCompleted::dispatch($subjectKey));
+
+                /* add jobs to the batch */
+                $pages
                 ->map(fn($id) => new ParseCrawledPage($id)) // Creates ParseCrawledPage jobs with IDs
                 ->pipe(fn(Collection $all) => $batch->add($all)); // Adds jobs to the batch
 
-
-                /* prepare the batches */
-//                $pages->mapInto(ParseCrawledPage::class)
-//                    ->pipe(fn(Collection $all) => $batch->add($all));
-
-                $batch->dispatch();
+                $batch->allowFailures()->dispatch();
 
                 Log::info('Webscrape: bus dispatched');
             });

--- a/src/Jobs/CrawlTargetJob.php
+++ b/src/Jobs/CrawlTargetJob.php
@@ -73,22 +73,28 @@ class CrawlTargetJob implements ShouldQueue
 
         Log::info("Webscrape: {$pages->count()} Pages crawled for subject ID: {$subjectKey}");
 
-        Bus::batch([
-            // Create jobs for parsing
-            $pages->map(fn($id) => new ParseCrawledPage($id)),
-        ])
-        ->then(function(Batch $batch) use($subjectKey, $pages) { // Use type hint Batch
-            // Create jobs for persisting parse results and processing them
-            Bus::batch([
-                $pages->map(fn($id) => new PersistParseResult($id)),
-                [new ProcessParsedResultsJob($subjectKey, $pages)],
-            ])->dispatch();
-        })
-        ->finally(fn(Batch $batch) => CrawlCompleted::dispatch($subjectKey)) // Use type hint Batch
-        ->allowFailures()
-        ->dispatch();
+        /* define the bus batch */
+        $batch = Bus::batch([])
+            ->then(function(Batch $batch) use($subjectKey, $pages){
+                $batch2 = Bus::batch([]);
+                /* add jobs to the batch */
+                $pages
+                    ->map(fn($id) => new PersistParseResult($id)) // Persist Parse result with Result IDs
+                    ->pipe(fn(Collection $all) => $batch2->add($all));
 
-        Log::info('Webscrape: batch dispatched');
+                $batch2->add([new ProcessParsedResultsJob($subjectKey, $pages)])
+                    ->dispatch();
+            })
+            ->finally(fn(Batch $batch) => CrawlCompleted::dispatch($subjectKey));
+
+        /* add jobs to the batch */
+        $pages
+            ->map(fn($id) => new ParseCrawledPage($id)) // Creates ParseCrawledPage jobs with IDs
+            ->pipe(fn(Collection $all) => $batch->add($all)); // Adds jobs to the batch
+
+        $batch->allowFailures()->dispatch();
+
+        Log::info('Webscrape: batch dispatched for subject ID: {$subjectKey}');
     }
 
     public function failed(\Throwable $exception): void

--- a/src/Jobs/ParseCrawledPage.php
+++ b/src/Jobs/ParseCrawledPage.php
@@ -48,7 +48,7 @@ class ParseCrawledPage implements ShouldQueue
 
         $batch->add([$this->handler($crawlResult)]);
 
-        if($batch->jobs->count() == 1 AND  $batch->jobs->first() instanceof $crawlResult->handler){
+        if($batch->jobs AND $batch->jobs->count() == 1 AND  $batch->jobs->first() instanceof $crawlResult->handler){
             $batch
                 ->dispatch();
         }

--- a/src/Jobs/ParseCrawledPage.php
+++ b/src/Jobs/ParseCrawledPage.php
@@ -9,9 +9,10 @@ use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\Log;
-use TrueRcm\LaravelWebscrape\Contracts\CrawlResult;
+//use TrueRcm\LaravelWebscrape\Contracts\CrawlResult;
 use TrueRcm\LaravelWebscrape\Contracts\ParsePage;
 use TrueRcm\LaravelWebscrape\Exceptions\CrawlException;
+use TrueRcm\LaravelWebscrape\Models\CrawlResult;
 
 class ParseCrawledPage implements ShouldQueue
 {
@@ -21,9 +22,11 @@ class ParseCrawledPage implements ShouldQueue
     use Queueable;
     use SerializesModels;
 
-    public function __construct(
-        protected CrawlResult $crawlResult
-    ) {
+    protected int $crawlResultId; // Holds the ID of the CrawlResult
+
+    public function __construct(int $crawlResultId)
+    {
+        $this->crawlResultId = $crawlResultId; // Store the ID
     }
 
     /**
@@ -32,12 +35,31 @@ class ParseCrawledPage implements ShouldQueue
      */
     public function handle(): void
     {
-        Log::info("Webscrape: enter-parsing-result-job {$this->crawlResult->id}");
+        // Retrieve the CrawlResult object from the database or any other data source
+        $crawlResult = $this->getCrawlResult();
+
+        if (!$crawlResult) {
+            Log::error("Webscrape: CrawlResult not found for ID {$this->crawlResultId}");
+            return;
+        }
+
+        Log::info("Webscrape: enter-parsing-result-job {$crawlResult->id}");
 
         $this->handler()
-            ->dispatch($this->crawlResult);
+            ->dispatch($crawlResult);
 
-        Log::info("Webscrape: dispatched-parsing-result-job {$this->crawlResult->handler}");
+        Log::info("Webscrape: dispatched-parsing-result-job {$crawlResult->handler}");
+    }
+
+    /**
+     * Retrieve the CrawlResult by ID.
+     *
+     * @return \TrueRcm\LaravelWebscrape\Contracts\CrawlResult|null
+     */
+    protected function getCrawlResult(): ?CrawlResult
+    {
+        // Assuming CrawlResult is an Eloquent model or a repository method
+        return CrawlResult::find($this->crawlResultId);
     }
 
     /**
@@ -47,10 +69,10 @@ class ParseCrawledPage implements ShouldQueue
     protected function handler(): ParsePage
     {
         throw_unless(
-            class_exists($this->crawlResult->handler),
-            CrawlException::parsingJobNotFound($this->crawlResult)
+            class_exists($this->getCrawlResult()->handler),
+            CrawlException::parsingJobNotFound($this->getCrawlResult())
         );
 
-        return resolve($this->crawlResult->handler);
+        return resolve($this->getCrawlResult()->handler);
     }
 }

--- a/src/Jobs/ParseCrawledPage.php
+++ b/src/Jobs/ParseCrawledPage.php
@@ -73,7 +73,7 @@ class ParseCrawledPage implements ShouldQueue
             CrawlException::parsingJobNotFound($this->getCrawlResult())
         );
 
-        return resolve($this->getCrawlResult()->handler);
+        return resolve($this->getCrawlResult()->handler,['crawlResultId' => $this->crawlResultId]);
     }
 
     /**

--- a/src/Jobs/ParseCrawledPage.php
+++ b/src/Jobs/ParseCrawledPage.php
@@ -84,6 +84,12 @@ class ParseCrawledPage implements ShouldQueue
     protected function getCrawlResult(): ?CrawlResult
     {
         // Assuming CrawlResult is an Eloquent model or a repository method
-        return app(CrawlResult::class)->find($this->crawlResultId);
+        $crawlResult = app(CrawlResult::class)->find($this->crawlResultId);
+
+        if (!$crawlResult) {
+            Log::error("CrawlResult not found for ID {$this->crawlResultId}");
+        }
+
+        return $crawlResult;
     }
 }

--- a/src/Jobs/ParseCrawledPage.php
+++ b/src/Jobs/ParseCrawledPage.php
@@ -37,23 +37,38 @@ class ParseCrawledPage implements ShouldQueue
     {
         Log::info("Webscrape: enter-parsing-result-job {$this->crawlResultId}");
 
-        $this->batch()->add([$this->handler()]);
+        $crawlResult = $this->getCrawlResult();
 
-        Log::info("Webscrape: dispatched-parsing-result-job {$this->getCrawlResult()->handler}");
+        if (!$crawlResult) {
+            Log::error("CrawlResult not found for ID {$this->crawlResultId} in handler()");
+            throw CrawlException::crawlResultNotFound($this->crawlResultId);
+        }
+
+        $batch = $this->batch() ?: Bus::batch([]);
+
+        $batch->add([$this->handler($crawlResult)]);
+
+        if($batch->jobs->count() == 1 AND  $batch->jobs->first() instanceof $crawlResult->handler){
+            $batch
+                ->dispatch();
+        }
+
+        Log::info("Webscrape: dispatched-parsing-result-job {$crawlResult->handler}");
     }
 
     /**
+     * @param \TrueRcm\LaravelWebscrape\Contracts\CrawlResult $crawlResult
      * @return \TrueRcm\LaravelWebscrape\Contracts\ParsePage
      * @throws \Throwable
      */
-    protected function handler(): ParsePage
+    protected function handler(CrawlResult $crawlResult): ParsePage
     {
         throw_unless(
-            class_exists($this->getCrawlResult()->handler),
-            CrawlException::parsingJobNotFound($this->getCrawlResult())
+            class_exists($crawlResult->handler),
+            CrawlException::parsingJobNotFound($crawlResult)
         );
 
-        return resolve($this->getCrawlResult()->handler,['crawlResultId' => $this->crawlResultId]);
+        return resolve($crawlResult->handler, ['crawlResultId' => $this->crawlResultId]);
     }
 
     /**
@@ -64,12 +79,6 @@ class ParseCrawledPage implements ShouldQueue
     protected function getCrawlResult(): ?CrawlResult
     {
         // Assuming CrawlResult is an Eloquent model or a repository method
-        $crawlResult = app(CrawlResult::class)->find($this->crawlResultId);
-
-        if (!$crawlResult) {
-            Log::error("CrawlResult not found for ID {$this->crawlResultId}");
-        }
-
-        return $crawlResult;
+        return app(CrawlResult::class)->find($this->crawlResultId);
     }
 }

--- a/src/Jobs/ParseCrawledPage.php
+++ b/src/Jobs/ParseCrawledPage.php
@@ -48,7 +48,7 @@ class ParseCrawledPage implements ShouldQueue
         $this->handler()
             ->dispatch($this->crawlResultId);
 
-//        Log::info("Webscrape: dispatched-parsing-result-job {$crawlResult->handler}");
+        Log::info("Webscrape: dispatched-parsing-result-job {$this->getCrawlResult()->handler}");
     }
 
     /**
@@ -74,5 +74,16 @@ class ParseCrawledPage implements ShouldQueue
         );
 
         return resolve($this->getCrawlResult()->handler);
+    }
+
+    /**
+     * Retrieve the CrawlResult by ID.
+     *
+     * @return \TrueRcm\LaravelWebscrape\Contracts\CrawlResult|null
+     */
+    protected function getCrawlResult(): ?CrawlResult
+    {
+        // Assuming CrawlResult is an Eloquent model or a repository method
+        return app(CrawlResult::class)->find($this->crawlResultId);
     }
 }

--- a/src/Jobs/ParseCrawledPage.php
+++ b/src/Jobs/ParseCrawledPage.php
@@ -9,10 +9,10 @@ use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\Log;
-//use TrueRcm\LaravelWebscrape\Contracts\CrawlResult;
+use TrueRcm\LaravelWebscrape\Contracts\CrawlResult;
 use TrueRcm\LaravelWebscrape\Contracts\ParsePage;
 use TrueRcm\LaravelWebscrape\Exceptions\CrawlException;
-use TrueRcm\LaravelWebscrape\Models\CrawlResult;
+//use TrueRcm\LaravelWebscrape\Models\CrawlResult;
 
 class ParseCrawledPage implements ShouldQueue
 {
@@ -36,19 +36,19 @@ class ParseCrawledPage implements ShouldQueue
     public function handle(): void
     {
         // Retrieve the CrawlResult object from the database or any other data source
-        $crawlResult = $this->getCrawlResult();
+//        $crawlResult = $this->getCrawlResult();
 
-        if (!$crawlResult) {
-            Log::error("Webscrape: CrawlResult not found for ID {$this->crawlResultId}");
-            return;
-        }
+//        if (!$crawlResult) {
+//            Log::error("Webscrape: CrawlResult not found for ID {$this->crawlResultId}");
+//            return;
+//        }
 
-        Log::info("Webscrape: enter-parsing-result-job {$crawlResult->id}");
+        Log::info("Webscrape: enter-parsing-result-job {$this->crawlResultId}");
 
         $this->handler()
-            ->dispatch($crawlResult);
+            ->dispatch($this->crawlResultId);
 
-        Log::info("Webscrape: dispatched-parsing-result-job {$crawlResult->handler}");
+//        Log::info("Webscrape: dispatched-parsing-result-job {$crawlResult->handler}");
     }
 
     /**
@@ -56,11 +56,11 @@ class ParseCrawledPage implements ShouldQueue
      *
      * @return \TrueRcm\LaravelWebscrape\Contracts\CrawlResult|null
      */
-    protected function getCrawlResult(): ?CrawlResult
-    {
-        // Assuming CrawlResult is an Eloquent model or a repository method
-        return CrawlResult::find($this->crawlResultId);
-    }
+//    protected function getCrawlResult(): ?CrawlResult
+//    {
+//        // Assuming CrawlResult is an Eloquent model or a repository method
+//        return app(CrawlResult::class)->find($this->crawlResultId);
+//    }
 
     /**
      * @return \TrueRcm\LaravelWebscrape\Contracts\ParsePage

--- a/src/Jobs/ParsePagesJob.php
+++ b/src/Jobs/ParsePagesJob.php
@@ -33,7 +33,7 @@ class ParsePagesJob implements ShouldQueue
     {
         Log::info('Webscrape: enter-parser-job');
 
-        $this->pages->each(fn (CrawlResult $page) => ParseCrawledPage::dispatch($page));
+        $this->pages->each(fn (CrawlResult $page) => ParseCrawledPage::dispatch($page->getKey()));
     }
 }
 

--- a/src/Jobs/PersistParseResult.php
+++ b/src/Jobs/PersistParseResult.php
@@ -8,13 +8,13 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
-use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Log;
+use TrueRcm\LaravelWebscrape\Actions\UpdateCrawlResult;
 use TrueRcm\LaravelWebscrape\Contracts\CrawlResult;
-use TrueRcm\LaravelWebscrape\Contracts\ParsePage;
-use TrueRcm\LaravelWebscrape\Exceptions\CrawlException;
+use TrueRcm\LaravelWebscrape\Enums\CrawlResultStatus;
 
-class ParseCrawledPage implements ShouldQueue
+class PersistParseResult implements ShouldQueue
 {
     use Batchable;
     use Dispatchable;
@@ -23,6 +23,7 @@ class ParseCrawledPage implements ShouldQueue
     use SerializesModels;
 
     protected int $crawlResultId; // Holds the ID of the CrawlResult
+    protected CrawlResult $crawlResult;
 
     public function __construct(int $crawlResultId)
     {
@@ -35,25 +36,24 @@ class ParseCrawledPage implements ShouldQueue
      */
     public function handle(): void
     {
-        Log::info("Webscrape: enter-parsing-result-job {$this->crawlResultId}");
+        $this->crawlResult = $this->getCrawlResult();
 
-        $this->batch()->add([$this->handler()]);
+        Log::info("Webscrape: enter-persist-parse-result-job for crawl-result {$this->crawlResult->id}");
 
-        Log::info("Webscrape: dispatched-parsing-result-job {$this->getCrawlResult()->handler}");
+        UpdateCrawlResult::run($this->crawlResult, $this->toArray());
+
+        Cache::forget($this->cacheKey());
+
+        Log::info("Webscrape: finished-persist-parse-result-job for crawl-result {$this->crawlResult->id}");
     }
 
-    /**
-     * @return \TrueRcm\LaravelWebscrape\Contracts\ParsePage
-     * @throws \Throwable
-     */
-    protected function handler(): ParsePage
+    protected function toArray(): array
     {
-        throw_unless(
-            class_exists($this->getCrawlResult()->handler),
-            CrawlException::parsingJobNotFound($this->getCrawlResult())
-        );
-
-        return resolve($this->getCrawlResult()->handler,['crawlResultId' => $this->crawlResultId]);
+        return [
+            'processed_at' => now(),
+            'result' => Cache::get($this->cacheKey()),
+            'process_status' => CrawlResultStatus::COMPLETED,
+        ];
     }
 
     /**
@@ -71,5 +71,10 @@ class ParseCrawledPage implements ShouldQueue
         }
 
         return $crawlResult;
+    }
+
+    public function cacheKey(): string
+    {
+        return 'App.CrawlResult.'.$this->crawlResult->getKey().'.parsed';
     }
 }

--- a/src/Jobs/PersistParseResult.php
+++ b/src/Jobs/PersistParseResult.php
@@ -14,6 +14,7 @@ use Illuminate\Support\Str;
 use TrueRcm\LaravelWebscrape\Actions\UpdateCrawlResult;
 use TrueRcm\LaravelWebscrape\Contracts\CrawlResult;
 use TrueRcm\LaravelWebscrape\Enums\CrawlResultStatus;
+use TrueRcm\LaravelWebscrape\Exceptions\CrawlException;
 
 class PersistParseResult implements ShouldQueue
 {
@@ -69,6 +70,7 @@ class PersistParseResult implements ShouldQueue
 
         if (!$crawlResult) {
             Log::error("CrawlResult not found for ID {$this->crawlResultId}");
+            throw CrawlException::crawlResultNotFound($this->crawlResultId);
         }
 
         return $crawlResult;

--- a/src/Jobs/PersistParseResult.php
+++ b/src/Jobs/PersistParseResult.php
@@ -10,6 +10,7 @@ use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
 use TrueRcm\LaravelWebscrape\Actions\UpdateCrawlResult;
 use TrueRcm\LaravelWebscrape\Contracts\CrawlResult;
 use TrueRcm\LaravelWebscrape\Enums\CrawlResultStatus;
@@ -75,6 +76,8 @@ class PersistParseResult implements ShouldQueue
 
     public function cacheKey(): string
     {
-        return 'App.CrawlResult.'.$this->crawlResult->getKey().'.parsed';
+        $key = 'App.CrawlResult.'.$this->crawlResult->getKey().'.parsed';
+        $sitePrefix = Str::slug(config('app.name', 'default-site'), '_');
+        return $sitePrefix. ':' . $key;
     }
 }

--- a/src/Jobs/ProcessParsedResultsJob.php
+++ b/src/Jobs/ProcessParsedResultsJob.php
@@ -2,6 +2,7 @@
 
 namespace TrueRcm\LaravelWebscrape\Jobs;
 
+use Illuminate\Bus\Batchable;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
@@ -11,17 +12,19 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Log;
 use TrueRcm\LaravelWebscrape\Actions\ParseFinalResult;
 use TrueRcm\LaravelWebscrape\Actions\UpdateCrawlSubject;
+use TrueRcm\LaravelWebscrape\Contracts\CrawlResult;
 use TrueRcm\LaravelWebscrape\Contracts\CrawlSubject;
 
 class ProcessParsedResultsJob implements ShouldQueue
 {
+    use Batchable;
     use Dispatchable;
     use InteractsWithQueue;
     use Queueable;
     use SerializesModels;
 
     public function __construct(
-        protected CrawlSubject $subject,
+        protected int $subjectId,
         protected Collection $pages
     ) {
     }
@@ -35,11 +38,14 @@ class ProcessParsedResultsJob implements ShouldQueue
     {
         Log::info('Webscrape: initiate-final-parser-job');
 
-        $finalResult = ParseFinalResult::run($this->pages)
+        $crawlSubject = app(CrawlSubject::class)->find($this->subjectId);
+        $crawlResults = app(CrawlResult::class)->whereKey($this->pages)->get();
+
+        $finalResult = ParseFinalResult::run($crawlResults)
             ->collapse()
             ->toArray();
 
-        UpdateCrawlSubject::run($this->subject, [
+        UpdateCrawlSubject::run($crawlSubject, [
                 'result' => $finalResult
             ]);
 

--- a/src/LaravelWebscrapeServiceProvider.php
+++ b/src/LaravelWebscrapeServiceProvider.php
@@ -62,7 +62,7 @@ class LaravelWebscrapeServiceProvider extends PackageServiceProvider
             fn ($app) => $app->make(TextExtractorService::class)
         );
 
-        $this->app->singleton(BrowserClient::class, function ($app) {
+        $this->app->bind(BrowserClient::class, function ($app) {
             /* locate the selenium instance */
             $driver = $app['config']->get('webscrape.selenium_driver_url');
             /* create a new client */

--- a/src/Models/Concerns/InteractsWithHasWebscrapes.php
+++ b/src/Models/Concerns/InteractsWithHasWebscrapes.php
@@ -3,6 +3,7 @@
 namespace TrueRcm\LaravelWebscrape\Models\Concerns;
 
 use Illuminate\Database\Eloquent\Relations\MorphMany;
+use Illuminate\Database\Eloquent\Relations\MorphOne;
 
 trait InteractsWithHasWebscrapes
 {
@@ -12,6 +13,15 @@ trait InteractsWithHasWebscrapes
     public function crawlSubjects(): MorphMany
     {
         return $this->morphMany(config('webscrape.models.subject'), 'model');
+    }
+
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\MorphOne
+     */
+    public function crawlSubject(): MorphOne
+    {
+        return $this->morphOne(config('webscrape.models.subject'), 'model')
+            ->latest();
     }
 
     /**

--- a/src/Pipes/AuthenticateBrowser.php
+++ b/src/Pipes/AuthenticateBrowser.php
@@ -5,6 +5,7 @@ namespace TrueRcm\LaravelWebscrape\Pipes;
 use Illuminate\Support\Facades\Log;
 use TrueRcm\LaravelWebscrape\Contracts\BrowserClient;
 use TrueRcm\LaravelWebscrape\CrawlTraveller;
+use TrueRcm\LaravelWebscrape\Events\CrawlAuthFailed;
 use TrueRcm\LaravelWebscrape\Exceptions\CrawlException;
 
 class AuthenticateBrowser
@@ -23,20 +24,22 @@ class AuthenticateBrowser
     {
         Log::info('Webscrape: enter-authentication');
 
-        $this->browser
-            ->request('GET', $traveller->authUrl());
+        if($traveller->doNotCrawlOldPages()){
+            $this->browser
+                ->request('GET', $traveller->authUrl());
 
-        $crawler = $this->browser
-            ->submitForm($traveller->authButtonIdentifier(), $traveller->getCrawlingCredentials());
+            $crawler = $this->browser
+                ->submitForm($traveller->authButtonIdentifier(), $traveller->getCrawlingCredentials());
 
-        throw_if(
-            $crawler->getUri() == $traveller->authUrl() /* is not good */,
-            CrawlException::authenticationFailed($traveller)
-        );
+            if($crawler->getUri() == 'https://proview.caqh.org/Login?Type=PR'){
+                CrawlAuthFailed::dispatch($traveller->subject()->id);
+                throw CrawlException::authenticationFailed($traveller);
+            }
 
-        $traveller->subject()->touch();
+            $traveller->subject()->update(['authenticated_at' => now()]);
 
-        $traveller->setBrowser($this->browser);
+            $traveller->setBrowser($this->browser);
+        }
 
         Log::info('Webscrape: finished-authentication');
 

--- a/src/Pipes/CloseBrowser.php
+++ b/src/Pipes/CloseBrowser.php
@@ -13,7 +13,9 @@ class CloseBrowser
      */
     public function handle(CrawlTraveller $traveller, \Closure $next)
     {
-        $traveller->clearBrowser();
+        if($traveller->doNotCrawlOldPages()) {
+            $traveller->clearBrowser();
+        }
 
         return $next($traveller);
     }

--- a/src/Pipes/CrawlPages.php
+++ b/src/Pipes/CrawlPages.php
@@ -19,24 +19,27 @@ class CrawlPages
     {
         Log::info('Webscrape: enter-crawling');
 
-        foreach ($traveller->targets() as $target) {
-            Log::info("Webscrape: started-crawling {$target->url}");
+        if($traveller->doNotCrawlOldPages()) {
 
-            /* it cannot be try/catch as we want to continue on fail to @todo extract into a sync job, possibly, if it does not serialize the browser */
-            $traveller->getBrowser()->request('GET', $target->url);
-            $crawler = $traveller->getBrowser()->waitForInvisibility('div#loading');
-            $crawler = new Crawler($crawler->html());
-            $responseCode = $traveller->getBrowser()->executeScript('return window.performance.getEntries()[0].responseStatus');
+            foreach ($traveller->targets() as $target) {
+                Log::info("Webscrape: started-crawling {$target->url}");
 
-            $page = AddCrawlResult::run($traveller->subject(), $target, [
-                'url' => $target->url,
-                'status' => $responseCode,
-                'body' => $crawler->filter('body')->html(), /* html */
-                'handler' => $target->handler,
-                'process_status' => CrawlResultStatus::PENDING,
-            ]);
+                /* it cannot be try/catch as we want to continue on fail to @todo extract into a sync job, possibly, if it does not serialize the browser */
+                $traveller->getBrowser()->request('GET', $target->url);
+                $crawler = $traveller->getBrowser()->waitForInvisibility('div#loading');
+                $crawler = new Crawler($crawler->html());
+                $responseCode = $traveller->getBrowser()->executeScript('return window.performance.getEntries()[0].responseStatus');
 
-            $traveller->addCrawledPage($page);
+                $page = AddCrawlResult::run($traveller->subject(), $target, [
+                    'url' => $target->url,
+                    'status' => $responseCode,
+                    'body' => $crawler->filter('body')->html(), /* html */
+                    'handler' => $target->handler,
+                    'process_status' => CrawlResultStatus::PENDING,
+                ]);
+
+                $traveller->addCrawledPage($page);
+            }
         }
 
         Log::info('Webscrape: finished-crawling');

--- a/tests/Feature/BrowserTest.php
+++ b/tests/Feature/BrowserTest.php
@@ -4,7 +4,7 @@ use Symfony\Component\Panther\Client;
 use TrueRcm\LaravelWebscrape\Browser;
 
 it('will forward calls to client from browser proxy', function () {
-    $client = $this->mock(Client::class);
+    $client = Mockery::mock(Client::class);
 
     $client
         ->expects('whatever')

--- a/tests/Feature/CrawlTravellerTest.php
+++ b/tests/Feature/CrawlTravellerTest.php
@@ -30,6 +30,23 @@ it('can set and get browser on traveller', function () {
     $this->assertSame($browser, $traveller->getBrowser());
 });
 
+it('can set to crawl old pages', closure: function ($subject) {
+    $crawlResults = CrawlResult::factory()
+        ->for($subject)
+        ->count(2)
+        ->create();
+
+    $stub = CrawlTraveller::make($subject);
+
+    $result = $stub->crawlOldPages();
+    $this->assertSame($result, $stub);
+    $this->assertFalse($stub->doNotCrawlOldPages());
+
+    $pages = $stub->getCrawledPages();
+    $this->assertCount(2, $pages);
+    $this->assertTrue($pages->pluck('id')->diff($crawlResults->pluck('id'))->isEmpty());
+})->with('subject');
+
 it('can get target urls from traveller', function ($subject) {
     $traveller = CrawlTraveller::make($subject);
 

--- a/tests/Feature/Events/CrawlCompletedTest.php
+++ b/tests/Feature/Events/CrawlCompletedTest.php
@@ -6,7 +6,7 @@ use TrueRcm\LaravelWebscrape\Models\CrawlSubject;
 it('will create new CrawlCompleted event instance', function () {
     $subject = CrawlSubject::factory()->create(['id' => 111]);
 
-    $event = new CrawlCompleted($subject);
+    $event = new CrawlCompleted(111);
 
-    $this->assertSame($subject, $event->subject);
+    $this->assertTrue($subject->is($event->subject));
 });

--- a/tests/Feature/Events/CrawlFailedTest.php
+++ b/tests/Feature/Events/CrawlFailedTest.php
@@ -1,0 +1,12 @@
+<?php
+
+use TrueRcm\LaravelWebscrape\Events\CrawlFailed;
+use TrueRcm\LaravelWebscrape\Models\CrawlSubject;
+
+it('will create new CrawlFailed event instance', function () {
+    $subject = CrawlSubject::factory()->create(['id' => 111]);
+
+    $event = new CrawlFailed($subject);
+
+    $this->assertSame($subject, $event->subject);
+});

--- a/tests/Feature/Exceptions/CrawlExceptionTest.php
+++ b/tests/Feature/Exceptions/CrawlExceptionTest.php
@@ -30,7 +30,7 @@ it('will handle authenticationFailed exception', function () {
     $this->assertInstanceOf(CrawlException::class, $stub);
 
     $this->assertEquals(
-        'Authentication failed for given credentials',
+        'Authentication failed for subject Id ',
         $stub->getMessage()
     );
 });
@@ -60,3 +60,16 @@ it('will handle parsing job not found exception', function () {
         $stub->getMessage()
     );
 });
+
+it('will handle crawl result not found exception', function () {
+    $stub = CrawlException::crawlResultNotFound(11);
+
+    $this->assertInstanceOf(CrawlException::class, $stub);
+
+    $this->assertEquals(
+        'CrawlResult not found for Id 11',
+        $stub->getMessage()
+    );
+});
+
+

--- a/tests/Feature/Jobs/CrawlTargetJobTest.php
+++ b/tests/Feature/Jobs/CrawlTargetJobTest.php
@@ -4,83 +4,196 @@ use Illuminate\Bus\PendingBatch;
 use Illuminate\Pipeline\Pipeline;
 use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Log;
+use Laravel\SerializableClosure\SerializableClosure;
 use Mockery\MockInterface;
+use TrueRcm\LaravelWebscrape\Actions\UpdateCrawlResult;
+use TrueRcm\LaravelWebscrape\Actions\UpdateCrawlSubject;
 use TrueRcm\LaravelWebscrape\CrawlTraveller;
 use TrueRcm\LaravelWebscrape\Events\CrawlCompleted;
+use TrueRcm\LaravelWebscrape\Events\CrawlFailed;
 use TrueRcm\LaravelWebscrape\Events\CrawlStarted;
 use TrueRcm\LaravelWebscrape\Jobs\CrawlTargetJob;
 use TrueRcm\LaravelWebscrape\Jobs\ParseCrawledPage;
+use TrueRcm\LaravelWebscrape\Jobs\PersistParseResult;
 use TrueRcm\LaravelWebscrape\Jobs\ProcessParsedResultsJob;
 use TrueRcm\LaravelWebscrape\Models\CrawlResult;
 use TrueRcm\LaravelWebscrape\Models\CrawlSubject;
 use TrueRcm\LaravelWebscrape\Pipes\AuthenticateBrowser;
 use TrueRcm\LaravelWebscrape\Pipes\CloseBrowser;
 use TrueRcm\LaravelWebscrape\Pipes\CrawlPages;
+use TrueRcm\LaravelWebscrape\Tests\Fixtures\SubjectContainerModel;
 
-it('can send traveller through pipelines', function () {
-    Event::fake();
-    Bus::fake();
+it('it passes traveller through expected pipeline stages', function () {
+    Log::spy();
 
+    $traveller = Mockery::mock(CrawlTraveller::class);
     $subject = CrawlSubject::factory()->create(['id' => 111]);
 
+    $traveller->shouldReceive('subject')->andReturn($subject);
+    $traveller->shouldReceive('getCrawledPages')->andReturn(collect());
+    $traveller->shouldReceive('clearBrowser')->once();
+
+    // Spy on job to confirm dispatchPostCrawlJobs is called
+    $job = Mockery::mock(CrawlTargetJob::class, [$traveller])
+        ->makePartial();
+
+    $job->shouldAllowMockingProtectedMethods();
+    $job->shouldReceive('dispatchPostCrawlJobs')->once();
+
+    $pipeline = Mockery::mock(Pipeline::class);
+    $pipeline->shouldReceive('send')->with($traveller)->andReturnSelf();
+    $pipeline->shouldReceive('through')
+        ->with([
+            AuthenticateBrowser::class,
+            CrawlPages::class,
+            CloseBrowser::class,
+        ])
+        ->andReturnSelf();
+
+    $pipeline->shouldReceive('then')
+        ->andReturnUsing(function ($callback) use ($traveller) {
+            $callback($traveller);
+        });
+
+    $job->handle($pipeline);
+
+    Log::shouldHaveReceived('info')->withArgs(function ($msg) {
+        return str_contains($msg, 'initiated for subject ID');
+    });
+});
+
+it('it handles exception thrown from pipeline', function () {
+    Bus::fake();
+    Event::fake();
+    Log::spy();
+
+    $traveller = Mockery::mock(CrawlTraveller::class);
+    $subject = CrawlSubject::factory()->create(['id' => 111]);
+
+    $traveller->shouldReceive('subject')->andReturn($subject);
+    $traveller->shouldReceive('clearBrowser')->once();
+
+    $pipeline = Mockery::mock(Pipeline::class);
+    $pipeline->shouldReceive('send')->andThrow(new \RuntimeException('pipe error'));
+
+    // Expect UpdateCrawlSubject::run to be invoked
+    $this->mock(UpdateCrawlSubject::class, function (MockInterface $mock) use ($subject) {
+        $mock->expects('handle')
+            ->once()
+            ->with($subject, [
+                'result' => []
+            ])
+            ->andReturn($subject);
+    });
+
+    $job = new CrawlTargetJob($traveller);
+    $job->handle($pipeline);
+
+    Event::assertDispatched(CrawlStarted::class);
+    Event::assertDispatched(CrawlFailed::class);
+    Log::shouldHaveReceived('error')->withArgs(function ($msg, $context) {
+        return str_contains($msg, 'Job failed for subject') &&
+            $context['error'] === 'pipe error';
+    });
+});
+
+it('it generates unique job id', function () {
+    config(['app.name' => 'My Test Site']);
+    SubjectContainerModel::migrate();
+
+    $traveller = Mockery::mock(CrawlTraveller::class);
+    $subject = CrawlSubject::factory()
+        ->for(SubjectContainerModel::factory()->create(['id' => 201]), 'model')
+        ->create(['id' => 111]);
+
+    $traveller->shouldReceive('subject')->andReturn($subject);
+
+    $job = new CrawlTargetJob($traveller);
+
+    $uniqueId = $job->uniqueId();
+
+    $this->assertSame('my_test_site:201', $uniqueId);
+});
+
+it('dispatch post crawl jobs creates expected batches', function () {
+    Bus::fake();
+    Event::fake();
+    Log::spy();
+
+    $traveller = Mockery::mock(CrawlTraveller::class);
+    $subject = CrawlSubject::factory()->create(['id' => 111]);
     $crawledResults = CrawlResult::factory()
         ->count(2)
         ->create();
 
-    $traveller = $this->mock(CrawlTraveller::class, function (MockInterface $mock) use ($crawledResults, $subject) {
-        $mock->expects('subject')
-            ->times(2)
-            ->andReturn($subject);
-
-        $mock->expects('getCrawledPages')
-            ->andReturn($crawledResults);
-    });
-
-    $pipeline = $this->mock(Pipeline::class, function (MockInterface $mock) use ($traveller) {
-        $mock->expects('send')
-            ->with($traveller)
-            ->andReturnSelf();
-
-        $mock
-            ->expects('through')
-            ->with([
-                AuthenticateBrowser::class,
-                CrawlPages::class,
-                CloseBrowser::class,
-            ])
-            ->andReturnSelf();
-
-        $mock
-            ->expects('then')
-            ->andReturnUsing(fn ($next) => $next($traveller));
-    });
+    $traveller->shouldReceive('subject')->andReturn($subject);
+    $traveller->shouldReceive('getCrawledPages')
+        ->andReturn($crawledResults);
 
     $job = new CrawlTargetJob($traveller);
+    // ✅ Call protected method via reflection
+    $reflection = new \ReflectionMethod($job, 'dispatchPostCrawlJobs');
+    $reflection->setAccessible(true);
+    $reflection->invoke($job, $traveller);
 
-    $job->handle($pipeline);
+    Bus::assertBatched(function (PendingBatch $batch) {
+        $jobs = collect($batch->jobs);
+        $jobs->contains(fn($job) => $this->assertInstanceOf(ParseCrawledPage::class, $job));
 
-    Bus::assertBatched(function (PendingBatch  $batch) use($subject){
-        $this->assertCount(2, $batch->jobs);
-        $batch->jobs->each(fn($job) => $this->assertInstanceOf(ParseCrawledPage::class, $job));
-
-        /* @var \Illuminate\Queue\SerializableClosure $thenCallback */
+        /* @var \Laravel\SerializableClosure\SerializableClosure $thenCallback */
         [$thenCallback] = $batch->thenCallbacks();
         [$finallyCallback] = $batch->finallyCallbacks();
 
 
-        $thenCallback->getClosure()->call($this, $this);
-        $finallyCallback->getClosure()->call($this, $this);
-
-        Bus::assertDispatched(ProcessParsedResultsJob::class, 1);
-        Event::assertDispatched(
-            CrawlCompleted::class,
-            fn (CrawlCompleted $event) => $subject->is($event->subject));
+        $thenCallback->getClosure()->call($batch, $batch);
+        $finallyCallback->getClosure()->call($batch, $batch);
 
         return true;
     });
 
-    Event::assertDispatched(
-        CrawlStarted::class,
-        fn (CrawlStarted $event) => $subject->is($event->subject));
+    Bus::assertBatched(function (PendingBatch $batch) {
+        $jobs = collect($batch->jobs);
+        return $jobs->contains(fn($j) => $j instanceof PersistParseResult)
+            || $jobs->contains(fn($j) => $j instanceof ProcessParsedResultsJob);
+    });
 
+    Event::assertDispatched(CrawlCompleted::class);
+
+    Log::shouldHaveReceived('info')->withArgs(function ($msg) {
+        return str_contains($msg, 'Pages crawled for subject ID');
+    });
+    Log::shouldHaveReceived('info')->withArgs(function ($msg) {
+        return str_contains($msg, 'batch dispatched for subject ID');
+    });
+});
+
+it('it can directly invoke failed method', function () {
+
+    Event::fake();
+    Log::spy();
+
+    $traveller = Mockery::mock(CrawlTraveller::class);
+    $subject = CrawlSubject::factory()->create(['id' => 111]);
+
+    $traveller->shouldReceive('subject')->andReturn($subject);
+
+    // Expect UpdateCrawlSubject::run to be invoked
+    $this->mock(UpdateCrawlSubject::class, function (MockInterface $mock) use ($subject) {
+        $mock->expects('handle')
+            ->once()
+            ->with($subject, [
+                'result' => []
+            ])
+            ->andReturn($subject);
+    });
+
+    $job = new CrawlTargetJob($traveller);
+    $job->failed(new \RuntimeException('boom'));
+
+    Event::assertDispatched(CrawlFailed::class);
+    Log::shouldHaveReceived('error')->withArgs(function ($msg, $context) {
+        return str_contains($msg, 'Job failed for subject') &&
+            $context['error'] === 'boom';
+    });
 });

--- a/tests/Feature/Jobs/ParseCrawledPageTest.php
+++ b/tests/Feature/Jobs/ParseCrawledPageTest.php
@@ -1,17 +1,32 @@
 <?php
 
+use Illuminate\Bus\PendingBatch;
 use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Log;
 use TrueRcm\LaravelWebscrape\Exceptions\CrawlException;
 use TrueRcm\LaravelWebscrape\Jobs\ParseCrawledPage;
 use TrueRcm\LaravelWebscrape\Models\CrawlResult;
 use TrueRcm\LaravelWebscrape\Tests\Fixtures\ParseHtmlJob;
 
+it('will throw exception when crawl result not found', function () {
+    Log::spy();
+    $this->expectException(CrawlException::class);
+
+    $job = new ParseCrawledPage(111);
+
+    $job->handle();
+
+    Log::shouldHaveReceived('error')->withArgs(function ($msg, $context) {
+        return str_contains($msg, 'CrawlResult not found for ID 111');
+    });
+});
+
 it('will throw exception when parsing job not found', function () {
     $this->expectException(CrawlException::class);
 
-    $crawlResult = CrawlResult::factory()->create(['handler' => '']);
+    $crawlResult = CrawlResult::factory()->create(['id' => 111, 'handler' => '']);
 
-    $job = new ParseCrawledPage($crawlResult);
+    $job = new ParseCrawledPage(111);
 
     $job->handle();
 });
@@ -19,11 +34,13 @@ it('will throw exception when parsing job not found', function () {
 it('will handle dispatching the job to parse crawled page', function () {
     Bus::fake();
 
-    $crawlResult = CrawlResult::factory()->create(['handler' => ParseHtmlJob::class]);
+    $crawlResult = CrawlResult::factory()->create(['id' => 111, 'handler' => ParseHtmlJob::class]);
 
-    $job = new ParseCrawledPage($crawlResult);
+    $job = new ParseCrawledPage(111);
 
     $job->handle();
 
-    Bus::assertDispatched(ParseHtmlJob::class);
+    Bus::assertBatched(function ( $batch) {
+        return $batch->jobs->contains(fn($job) => $job instanceof ParseHtmlJob);
+    });
 });

--- a/tests/Feature/Jobs/PersistParseResultTest.php
+++ b/tests/Feature/Jobs/PersistParseResultTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace TrueRcm\LaravelWebscrape\Tests\Feature\Jobs;
+
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
+use Mockery;
+use Mockery\MockInterface;
+use TrueRcm\LaravelWebscrape\Actions\UpdateCrawlResult;
+use TrueRcm\LaravelWebscrape\Enums\CrawlResultStatus;
+use TrueRcm\LaravelWebscrape\Exceptions\CrawlException;
+use TrueRcm\LaravelWebscrape\Jobs\PersistParseResult;
+use TrueRcm\LaravelWebscrape\Models\CrawlResult;
+
+it('runs UpdateCrawlResult with expected arguments and clears cache', function () {
+    Log::spy();
+    Carbon::setTestNow('May 17, 2023 2:13 PM');
+    config(['app.name' => 'My Test Site']);
+
+    Log::shouldReceive('info')->times(2);
+
+    $crawlResult = CrawlResult::factory()->create(['id'=>111]);
+    Cache::put('my_test_site:App.CrawlResult.111.parsed', [
+        'some' => 'data'
+    ]);
+
+    $this->assertTrue(Cache::has('my_test_site:App.CrawlResult.111.parsed'));
+
+    $this->mock(UpdateCrawlResult::class, function (MockInterface $mock) use ($crawlResult) {
+        $mock->expects('handle')
+            ->once()
+            ->with(
+                Mockery::on(fn($arg) => $arg->is($crawlResult)), // same DB row
+                [
+                    'processed_at' => now(),
+                    'process_status' => CrawlResultStatus::COMPLETED,
+                    'result' => [
+                        'some' => 'data'
+                    ]
+                ]
+            )
+            ->andReturn($crawlResult);
+    });
+
+    $job = new PersistParseResult(111);
+    $job->handle();
+
+    $this->assertFalse(Cache::has('my_test_site:App.CrawlResult.111.parsed'));
+});
+
+it('will throw exception when crawl result not found', function () {
+    Log::spy();
+    $this->expectException(CrawlException::class);
+
+    $job = new PersistParseResult(111);
+
+    $job->handle();
+
+    Log::shouldHaveReceived('error')->withArgs(function ($msg, $context) {
+        return str_contains($msg, 'CrawlResult not found for ID 111');
+    });
+});
+
+it('generates correct cache key', function () {
+    config(['app.name' => 'My Test Site']);
+    CrawlResult::factory()->create(['id'=>111]);
+
+    $job = new PersistParseResult(111);
+    $job->handle();
+
+    $this->assertSame($job->cacheKey(), "my_test_site:App.CrawlResult.111.parsed");
+});

--- a/tests/Feature/Jobs/ProcessParsedResultsJobTest.php
+++ b/tests/Feature/Jobs/ProcessParsedResultsJobTest.php
@@ -2,6 +2,7 @@
 
 namespace TrueRcm\LaravelWebscrape\Tests\Feature\Jobs;
 
+use Mockery;
 use Mockery\MockInterface;
 use TrueRcm\LaravelWebscrape\Actions\ParseFinalResult;
 use TrueRcm\LaravelWebscrape\Actions\UpdateCrawlSubject;
@@ -18,27 +19,41 @@ class ProcessParsedResultsJobTest extends TestCase
         $subject = CrawlSubject::factory()->create(['id' => 111]);
 
         $crawledResults = CrawlResult::factory()
+            ->sequence(
+                [
+                    'id' => 222,
+                ],
+                [
+                    'id' => 333,
+                ]
+            )
             ->count(2)
             ->create();
 
         $this->mock(ParseFinalResult::class, function (MockInterface $mock) use ($crawledResults) {
             $mock->expects('handle')
                 ->once()
-                ->with($crawledResults)
+                ->with(Mockery::on(function ($arg) use ($crawledResults) {
+                    return $arg->count() === $crawledResults->count()
+                        && $arg->pluck('id')->diff($crawledResults->pluck('id'))->isEmpty();
+                }))
                 ->andReturn(collect([['name' => 'abc'],['email' => 'test@test.com']]));
         });
 
         $this->mock(UpdateCrawlSubject::class, function (MockInterface $mock) use ($subject) {
             $mock->expects('handle')
                 ->once()
-                ->with($subject, ['result' => [
-                    "name" => "abc",
-                    "email" => "test@test.com",
-                ]])
+                ->with(
+                    Mockery::on(fn($arg) => $arg->is($subject)), // same DB row
+                    ['result' => [
+                        "name" => "abc",
+                        "email" => "test@test.com",
+                    ]]
+                )
                 ->andReturn($subject);
         });
 
-        $job = new ProcessParsedResultsJob($subject, $crawledResults);
+        $job = new ProcessParsedResultsJob(111, collect([222, 333]));
 
         $job->handle();
     }

--- a/tests/Feature/Pipes/AuthenticateBrowserTest.php
+++ b/tests/Feature/Pipes/AuthenticateBrowserTest.php
@@ -54,7 +54,7 @@ it('will throw exception if invalid credential', function () {
 </html>
 HTML;
 
-    $crawler = new Crawler($html, 'http:://authenticate.test');
+    $crawler = new Crawler($html, 'https://proview.caqh.org/Login?Type=PR');
 
     $this->mock(BrowserClient::class, function (MockInterface $mock) use ($crawler) {
         $mock->shouldReceive('request')

--- a/tests/Feature/Pipes/CloseBrowserTest.php
+++ b/tests/Feature/Pipes/CloseBrowserTest.php
@@ -16,6 +16,8 @@ class CloseBrowserTest extends TestCase
                     $mock->expects('clearBrowser')
                         ->once()
                         ->andReturnSelf();
+
+                    $mock->shouldReceive('doNotCrawlOldPages')->andReturn(true);
                 });
 
     app(CloseBrowser::class)

--- a/tests/Fixtures/ParseHtmlJob.php
+++ b/tests/Fixtures/ParseHtmlJob.php
@@ -2,6 +2,7 @@
 
 namespace TrueRcm\LaravelWebscrape\Tests\Fixtures;
 
+use Illuminate\Bus\Batchable;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
@@ -12,6 +13,7 @@ use TrueRcm\LaravelWebscrape\Models\CrawlResult;
 
 class ParseHtmlJob implements ShouldQueue, ParsePage
 {
+    use Batchable;
     use Dispatchable;
     use InteractsWithQueue;
     use Queueable;


### PR DESCRIPTION
main

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new event class, `CrawlFailed`, to handle crawl failures.
	- Enhanced `CrawlTargetJob` with improved error handling and event dispatching for failed jobs.
	- Updated `ParseCrawledPage` to streamline handling of crawl results using an ID.
	- Added a new job class, `PersistParseResult`, for processing and persisting parsed results.
	- Modified `ProcessParsedResultsJob` to improve the retrieval of crawl results using identifiers.

- **Bug Fixes**
	- Improved robustness of job processing by implementing error handling mechanisms.

- **Tests**
	- Added a test case for verifying the creation of the `CrawlFailed` event instance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->